### PR TITLE
chore: cache cidr request promise in module scope

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -18,7 +18,7 @@ Download, then find the url out of your downloads list, then replace it here.
 At least the Github Action that runs this script fails when that becomes
 necessary.
 */
-const AZURE_IP_RANGES_URL = 'https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_20230703.json';
+const AZURE_IP_RANGES_URL = 'https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_20230724.json';
 
 const FETCH_TIMEOUT = 10000;
 


### PR DESCRIPTION
It's probably okay to keep it in module scope after the initial fetch and should not affect the telemetry too much. I'm "caching" the actual promise here so that parallel calls to the method can share the same request